### PR TITLE
NISD-Langs | English language syntax corrections

### DIFF
--- a/langs/lang.en.js
+++ b/langs/lang.en.js
@@ -1,7 +1,7 @@
 /*
     File della lingua del BOT NISD,
     @Authors: @Polliog#7772 | 𝓝𝓪𝓴𝓪𝓶𝓸𝓽𝓸 𝓢𝓱𝓲𝓰𝓮𝓽𝓸𝓴𝓲#0016
-    @Translated by: @Toofu#0001
+    @Translated by: @Toofu#0001 | Corrected by @TeknoSenpai#0957
 
     Note per tradurre questo file:
     - Non modificare il nome dei metodi, delle variabili, delle funzioni
@@ -74,7 +74,7 @@ const lang = {
     // Interaction Replies
     interaction_success: "Action completed",
     //ERRORS
-    bot_error: "An internal error occurred, the error will be automatically sent to the developers",
+    bot_error: "An internal error occurred, a report of the error will be automatically sent to the developers",
     error: "Error",
     insufficient_permissions: "Insufficient permissions",
     invalid_user: "Invalid user",
@@ -192,8 +192,8 @@ const lang = {
     members: "Members",
     channels: "Channels",
     server_use: "server",
-    server_description: "Display server information",
-    server_small_desc: 'Display server information',
+    server_description: "Displays server information",
+    server_small_desc: 'Displays server information',
     //SAY
     say_use: "say [Message]",
     say_description: "Make the bot repeat a message",
@@ -278,8 +278,7 @@ const lang = {
         "The user will remain mutated even if he leaves and re-enters the server.\n" +
         "**Please note that with servers with a custom default role the command may not work due to overriding permissions**",
     mute_small_desc: "Mute a user, time optional",
-    mute_examples:
-        "`mute ID`\n" +
+    mute_examples: "`mute ID`\n" +
         "`mute @User`\n" +
         "`mute @User 15m stop spamming`\n" +
         "`mute @User continuously annoys in voice chat`",
@@ -295,8 +294,7 @@ const lang = {
     unmute_use: "unmute [@User/ID] (reason)",
     unmute_description: "Unmute a user so that it can talk in the server again",
     unmute_small_desc: "Unmutes a user in the server",
-    unmute_examples:
-        "`unmute ID`\n" +
+    unmute_examples: "`unmute ID`\n" +
         "`unmute @User`\n" +
         "`unmute @User wrong person, sorry <3`",
     user_unmuted: "User Unmuted",
@@ -308,8 +306,7 @@ const lang = {
     muterole_description: "Set the role to use for the `mute` command\n" +
         "**:warning: Using this command the BOT will try to set the role in all channels on the server, to avoid this add `-n` to the command**",
     muterole_small_desc: "Set the role to use for the `mute` command",
-    muterole_examples:
-        "`muterole ID`\n" +
+    muterole_examples: "`muterole ID`\n" +
         "`muterole @Role`\n" +
         "`muterole @Rule -n`",
     muterole_saved: (role) => {
@@ -319,8 +316,7 @@ const lang = {
     warn_use: 'warn [@User/ID] (reason)',
     warn_description: 'warn a user',
     warn_small_desc: 'warn a user',
-    warn_examples:
-        "`warn ID`\n" +
+    warn_examples: "`warn ID`\n" +
         "`warn @User stop spamming`",
     user_warned: "User Warned",
     user_warned_dm: (guild) => {
@@ -330,8 +326,7 @@ const lang = {
     unwarn_use: "unwarn [@User/ID] [Number] (Reason)",
     unwarn_description: "Remove a warning from a user, to find the number of a warning use `warnings [@User]`",
     unwarn_small_desc: "Remove a warning from a user",
-    unwarn_examples:
-        "`unwarn ID 1`" +
+    unwarn_examples: "`unwarn ID 1`" +
         "`unwarn @User 2`\n" +
         "`unwarn @User 2 I forgive you bro`",
     user_unwarned: "Warn deleted",
@@ -342,8 +337,7 @@ const lang = {
     clearwarns_use: "clearwarns [@User/ID] (Reason)",
     clearwarns_description: "Clear all warnings given to a user",
     clearwarns_small_desc: "Clear all warnings for a user",
-    clearwarns_examples:
-        "`clearwarns ID`\n" +
+    clearwarns_examples: "`clearwarns ID`\n" +
         "`clearwarns @User`\n" +
         "`clearwarns @User you have taken forgiveness`",
     user_clearwarns: "Warns totally deleted",
@@ -354,8 +348,7 @@ const lang = {
     warnings_use: "warnings [@User/ID] (page)",
     warnings_description: "Watch warnings for a specific user",
     warnings_small_desc: "Watch warnings for a specific user",
-    warnings_examples:
-        "`warnings ID\n`" +
+    warnings_examples: "`warnings ID\n`" +
         "`warnings ID 2`\n" +
         "`warnings @Polliog`\n" +
         "`warnings @Polliog 2`",
@@ -366,8 +359,7 @@ const lang = {
     reportchannel_use: "reportchannel [#Channel/ID]",
     reportchannel_description: "Set a channel for user reports",
     reportchannel_small_desc: "Set a channel for user reports",
-    reportchannel_examples:
-        "`reportchannel ID`\n" +
+    reportchannel_examples: "`reportchannel ID`\n" +
         "`reportchannel #Channel`",
     reportchannel_saved: (channel) => {
         return `Reportchannel set, **New channel**:${channel}`
@@ -380,8 +372,7 @@ const lang = {
     prefix_description: "Set a custom prefix to the server, the BOT will respond to the new prefix and prefix `nisd`. \n" +
         "**You will still be able to tag the bot to see the prefix on this server**",
     prefix_small_desc: "Change the bot's prefix",
-    prefix_examples:
-        "`prefix ?`\n" +
+    prefix_examples: "`prefix ?`\n" +
         "`prefix n!!`",
     prefix_changed: (prefix) => {
         return `Bot prefix changed, **New prefix**: \`${prefix}\``
@@ -391,8 +382,7 @@ const lang = {
     mod_deleteAfter: "Delete Command",
     mod_dmUser: "Message User",
     mod_use: "mod logs | dms | delete {#Channel/ID/none} {True/False}",
-    mod_description:
-        "**Change settings regarding moderation**\n" +
+    mod_description: "**Change settings regarding moderation**\n" +
         ":small_blue_diamond: `mod logs [#Channel/ID/none]`\n" +
         "Set a channel to show the actions taken by the staff\n" +
         ":small_blue_diamond: `mod dms [True/False]`\n" +
@@ -400,8 +390,7 @@ const lang = {
         ":small_blue_diamond: `mod delete [True/False]`\n" +
         "Set whether to automatically delete the command on action taken",
     mod_small_desc: "Open moderation settings, use `mod` for info",
-    mod_examples:
-        "`mod dms true` \n" +
+    mod_examples: "`mod dms true` \n" +
         "`mod logs none` \n" +
         "`mod logs #Channel` \n" +
         "`mod delete true`",
@@ -410,8 +399,7 @@ const lang = {
     mod_logs_description: "Set a channel to show the actions taken by the staff\n" +
         "Use `none` instead of channel to disable logs",
     mod_logs_small_desc: "Set a channel to show actions taken by staff",
-    mod_logs_examples:
-        "mod logs ID" + "mod logs none" +
+    mod_logs_examples: "mod logs ID" + "mod logs none" +
         "`mod logs none`\n" +
         "`mod logs #Channel`",
     mod_logs_channel_saved: (channel) => {
@@ -422,8 +410,7 @@ const lang = {
     mod_dms_use: "mod dms [True/False]",
     mod_dms_description: "Set whether or not to send a private message to the user when the action is taken",
     mod_dms_small_desc: "Set whether or not to send a private message to the user when an action is taken",
-    mod_dms_examples:
-        "`mod dms true`" +
+    mod_dms_examples: "`mod dms true`" +
         "`mod dms false`",
     mod_dms_true: "Users will now be notified in the DMS",
     mod_dms_false: "Users will now no longer receive alerts in DMS",
@@ -431,8 +418,7 @@ const lang = {
     mod_delete_use: "mod delete [True/False]",
     mod_delete_description: "Set whether to automatically delete the command when the action is executed",
     mod_delete_small_desc: "Set whether to automatically delete the command when the action is executed",
-    mod_delete_examples:
-        "`mod delete true`\n" +
+    mod_delete_examples: "`mod delete true`\n" +
         "`mod delete false`",
     mod_delete_true: "Now the commands will be deleted when the action is finished",
     mod_delete_false: "Commands will now not be deleted when the action is finished",
@@ -440,8 +426,7 @@ const lang = {
     report_use: 'report [Message]',
     report_description: "Report something to the server staff (minimum 10 characters)",
     report_small_desc: "Report something to the server staff",
-    report_examples:
-        "`report Polliog offended my person :(`",
+    report_examples: "`report Polliog offended my person :(`",
     report_min_chars: "The message must be at least 10 characters long",
     report_not_configured: "No valid reporting channel is configured on the server.",
     report_sent: "Report sent!",
@@ -449,8 +434,7 @@ const lang = {
     poll_use: "poll \"[Title]\" \"[Option1]\" \"[Option2]\" \"(Options)\"",
     poll_description: "Create a poll with multiple options, maximum 9 options",
     poll_small_desc: "Create a poll with multiple options",
-    poll_examples:
-        '`poll "Better sushi or pizza?" "pizza bruh" "sushi"`',
+    poll_examples: '`poll "Better sushi or pizza?" "pizza bruh" "sushi"`',
     poll_max_options: "You can use maximum 9 options",
     //info
     info_bot: "Information about the bot",
@@ -460,8 +444,7 @@ const lang = {
     version: "Version",
     //anti-flood
     antiflood_use: "antiflood [enable/disable | limit | action | time] {Number} {Action}",
-    antiflood_description:
-        "The AntiFlood allows you to protect the server against people who write a lot of messages repeatedly\n" +
+    antiflood_description: "The AntiFlood allows you to protect the server against people who write a lot of messages repeatedly\n" +
         ":small_blue_diamond: `antiflood [enable/disable]`\n" +
         "Enable or disable AntiFlood\n" +
         ":small_blue_diamond: `antiflood limit [Limit]`\n" +
@@ -471,8 +454,7 @@ const lang = {
         ":small_blue_diamond: `antiflood time [Time]`\n" +
         "Sets the time **in seconds**, in which the flood is to be determined",
     antiflood_small_desc: "Open AntiFlood settings",
-    antiflood_examples:
-        "`antiflood enable`\n" +
+    antiflood_examples: "`antiflood enable`\n" +
         "`antiflood limit 4`\n" +
         "`antiflood action ban`\n" +
         "`antiflood time 5`",
@@ -480,8 +462,7 @@ const lang = {
     antiflood_mode_use: "antiflood [Enable | Disable]",
     antiflood_mode_description: 'Enable or disable AntiFlood',
     antiflood_mode_small_desc: 'Enable or disable AntiFlood',
-    antiflood_mode_examples:
-        "`antiflood enable`\n" +
+    antiflood_mode_examples: "`antiflood enable`\n" +
         "`antiflood disable`",
     antiflood_enabled: "`antiflood enable!`",
     antiflood_disabled: "AntiFlood disabled!",
@@ -499,8 +480,7 @@ const lang = {
     antiflood_action_use: "antiflood action [Ban | Kick | Warn | Mute | none]",
     antiflood_action_description: "Set the action the bot takes when it detects flooding, use \`none\` to take no action (other than delete messages)",
     antiflood_action_small_desc: "Set the action the bot takes when it detects flooding",
-    antiflood_action_examples:
-        "\`antiflood action ban\`\n" +
+    antiflood_action_examples: "\`antiflood action ban\`\n" +
         "\`antiflood action none\`",
     antiflood_action_updated: (action) => {
         return `antiflood action updated, **Action**: \`${action}\``
@@ -509,8 +489,7 @@ const lang = {
     antiflood_time_use: "antiflood time [Seconds]",
     antiflood_time_description: 'Set the time **in seconds**, in which the flood is to be determined',
     antiflood_time_small_desc: "Sets the time at which flooding is to be determined",
-    antiflood_time_examples:
-        "`antiflood time 4`",
+    antiflood_time_examples: "`antiflood time 4`",
     antiflood_time_min: "The minimum time limit for AntiFlood is 3 seconds",
     antiflood_time_updated: (time) => {
         return `Updated AntiFlood time, **New time**: \`${time} Seconds`
@@ -521,15 +500,13 @@ const lang = {
     antiflood_acted: "[NISD AutoMod] The user sent too many messages too fast!",
     //antispam
     antispam_use: "antispam [enable/disable | action] {Action}",
-    antispam_description:
-        "AntiSpam is a function that automatically deletes all spam messages (server invites) in the server" +
+    antispam_description: "AntiSpam is a function that automatically deletes all spam messages (server invites) in the server" +
         ":small_blue_diamond: `antispam [enable/disable]`\n" +
         "Enable or disable AntiSpam\n" +
         ":small_blue_diamond: `antispam action [Ban | Kick | Warn | Mute | none]`\n" +
         "Sets the action the bot takes when it detects a spam link",
     antispam_small_desc: "Open AntiSpam settings",
-    antispam_examples:
-        "`antispam enable`\n" +
+    antispam_examples: "`antispam enable`\n" +
         "`antispam action warn`",
     antispam_in_action: (member) => {
         return `${member}**, Invitation link detected!**`
@@ -540,8 +517,7 @@ const lang = {
     antispam_action_description: "Set the action the bot takes when it detects a spam message, " +
         "use `none` to take no action (other than deleting the message)",
     antispam_action_small_desc: "Set the action the bot takes if it detects spam",
-    antispam_action_examples:
-        "`antispam action ban`\n" +
+    antispam_action_examples: "`antispam action ban`\n" +
         "`antispam action none`",
     antispam_action_updated: (action) => {
         return `AntiSpam action updated **Action**: \`${action}\``
@@ -551,8 +527,7 @@ const lang = {
     antispam_disabled: "AntiSpam disabled!",
     //antinuke
     antinuke_use: "antinuke [Category] [limit | action | enable/disable] {Options}",
-    antinuke_description:
-        "To view the current settings use \`antinuke info\`\n\n" +
+    antinuke_description: "To view the current settings use \`antinuke info\`\n\n" +
         "Edit AntiNuke settings, to change a specific setting use `antinuke [category]`\n" +
         "If a user reaches the \"limit\" of an action, the bot punishes him, each action has its own punishment\n" +
         "You can set a global limit through `antinuke global [number]`\n\n" +
@@ -573,17 +548,16 @@ const lang = {
         ":small_blue_diamond: \`antinuke info\`\n" +
         "Check the current AntiNuke settings",
     antinuke_small_desc: "View all AntiNuke settings",
-    antinuke_examples:
-        "`antinuke info`\n" +
+    antinuke_examples: "`antinuke info`\n" +
         "`antinuke global 5`\n" +
         "`antinuke ban enable`\n" +
-        "antinuke kick action ban\n" +
-        "`antinuke rolecreate limit 4`" + "`antinuke rolecreate limit 4`",
+        "`antinuke kick action ban\n`" +
+        "`antinuke rolecreate limit 4\n`" +
+        "`antinuke rolecreate limit 4`",
     antinuke_warnings: "[ANTINUKE] Warning you are exceeding an AntiNuke limit",
     //antiban
     antiban_use: "antiban [limit | action | enable/disable] {Options}",
-    antiban_description:
-        "AntiBan is a function of AntiNuke that acts on users banning many members repeatedly\n" +
+    antiban_description: "AntiBan is a function of AntiNuke that acts on users banning many members repeatedly\n" +
         ":small_blue_diamond: \`enable/disable anti-ban\`\n" +
         "Enable/Disable AntiBan\n" +
         ":small_blue_diamond: \`AntiBan limit [Number]\`\n" +
@@ -591,8 +565,7 @@ const lang = {
         ":small_blue_diamond: \`Antiban action [Sanction]\`\n" +
         "Modify the AntiBan sanction",
     antiban_small_desc: "Modify the AntiBan settings of the AntiNuke",
-    antiban_examples:
-        "`antiban enable`\n" +
+    antiban_examples: "`antiban enable`\n" +
         "`antiban disable`\n" +
         "`antiban limit 5`\n" +
         "`antiban action ban`",
@@ -601,26 +574,21 @@ const lang = {
     antiban_acted: "[ANTIBAN] Large number of bans executed by the user detected",
     //antiban action
     antiban_action_use: "antiban action [Ban | Kick | Warn | Mute]",
-    antiban_action_description:
-        "Sets the action to be performed by the BOT if a user exceeds the set limit",
-    antiban_action_examples:
-        "`antiban action ban`",
+    antiban_action_description: "Sets the action to be performed by the BOT if a user exceeds the set limit",
+    antiban_action_examples: "`antiban action ban`",
     antiban_action_updated: (action) => {
         return `AntiBan action updated, **Action**: \`${action}`
     },
     //antiban limit
     antiban_limit_use: "antiban limit [Number]",
-    antiban_limit_description:
-        "Sets the limit for AntiNuke's AntiBan",
-    antiban_limit_examples:
-        "`antiban limit 3`",
+    antiban_limit_description: "Sets the limit for AntiNuke's AntiBan",
+    antiban_limit_examples: "`antiban limit 3`",
     antiban_limit_updated: (limit) => {
         return `AntiBan limit changed, **New limit**: \`${limit}\``
     },
     //antikick
     antikick_use: "antikick [limit | action | enable/disable] {Options}",
-    antikick_description:
-        "AntiKick is a function of AntiNuke that acts on users that expel many members repeatedly\n" +
+    antikick_description: "AntiKick is a function of AntiNuke that acts on users that expel many members repeatedly\n" +
         ":small_blue_diamond: \`antikick enable/disable\`\n" +
         "Enable/Disable Anti-Kick\n" +
         ":small_blue_diamond: \`antikick limit [Number]\`\n" +
@@ -628,8 +596,7 @@ const lang = {
         ":small_blue_diamond: \`antikick action [Sanction]\`\n" +
         "Modify the AntiKick sanction",
     antikick_small_desc: "Modifies the AntiKick settings of the AntiNuke",
-    antikick_examples:
-        "`antikick enable`\n" +
+    antikick_examples: "`antikick enable`\n" +
         "`antikick disable`\n" +
         "`antikick limit 5`\n" +
         "`antikick action ban`",
@@ -638,26 +605,21 @@ const lang = {
     antikick_acted: "[ANTIKICK] Large number of kicks executed by the user detected",
     //antikick action
     antikick_action_use: "antikick action [Ban | Kick | Warn | Mute]",
-    antikick_action_description:
-        "Sets the action to be performed by the BOT if a user exceeds the set limit",
-    antikick_action_examples:
-        "`antikick action ban`",
+    antikick_action_description: "Sets the action to be performed by the BOT if a user exceeds the set limit",
+    antikick_action_examples: "`antikick action ban`",
     antikick_action_updated: (action) => {
         return `antikick action updated, **Action**: \`${action}\``
     },
     //antikick limit
     antikick_limit_use: "antikick limit [Number]",
-    antikick_limit_description:
-        "Sets the limit for the AntiKick of the AntiNuke",
-    antikick_limit_examples:
-        "`antikick limit 3`",
+    antikick_limit_description: "Sets the limit for the AntiKick of the AntiNuke",
+    antikick_limit_examples: "`antikick limit 3`",
     antikick_limit_updated: (limit) => {
         return `AntiKick limit changed, **New Limit**: \`${limit}\``
     },
     //antirolecreate
     antirolecreate_use: "antirolecreate [limit | action | enable/disable] {Options}",
-    antirolecreate_description:
-        "AntiRoleCreate is a function of AntiNuke that acts on users who create many roles in a short time\n" +
+    antirolecreate_description: "AntiRoleCreate is a function of AntiNuke that acts on users who create many roles in a short time\n" +
         ":small_blue_diamond: \`antirolecreate enable/disable\`\n" +
         "Enable/Disable AntiRoleCreate\n" +
         ":small_blue_diamond: \`AntiRoleCreate limit [Number]\`\n" +
@@ -665,8 +627,7 @@ const lang = {
         ":small_blue_diamond: \`antirolecreate action [Sanction]\`\n" +
         "Modify the AntiRoleCreate sanction",
     antirolecreate_small_desc: "Modifies the AntiRoleCreate settings of the AntiNuke",
-    antirolecreate_examples:
-        "`antirolecreate enable`\n" +
+    antirolecreate_examples: "`antirolecreate enable`\n" +
         "`antirolecreate disable`\n" +
         "`antirolecreate limit 5`\n" +
         "`antirolecreate action ban`\n",
@@ -675,26 +636,21 @@ const lang = {
     antirolecreate_acted: "[ANTIROLECREATE] Large number of user-created roles detected",
     //anti-rolecreate action
     antirolecreate_action_use: "antirolecreate action [Ban | Kick | Warn | Mute]",
-    antirolecreate_action_description:
-        "Sets the action to be performed by the BOT if a user exceeds the set limit",
-    antirolecreate_action_examples:
-        "`antirolecreate action ban`",
+    antirolecreate_action_description: "Sets the action to be performed by the BOT if a user exceeds the set limit",
+    antirolecreate_action_examples: "`antirolecreate action ban`",
     antirolecreate_action_updated: (action) => {
         return `AntiRoleCreate action updated, **Action**: \`${action}`
     },
     //antirolecreate limit
     antirolecreate_limit_use: "antirolecreate limit [Number]",
-    antirolecreate_limit_description:
-        "Sets the limit for the AntiRoleCreate of the AntiNuke",
-    antirolecreate_limit_examples:
-        "`antirolecreate limit 3`",
+    antirolecreate_limit_description: "Sets the limit for the AntiRoleCreate of the AntiNuke",
+    antirolecreate_limit_examples: "`antirolecreate limit 3`",
     antirolecreate_limit_updated: (limit) => {
         return `Modified AntiRoleCreate Limit, **New Limit**: \`${limit}\``
     },
     //antiroledelete
     antiroledelete_use: "antiroledelete [limit | action | enable/disable] {Options}",
-    antiroledelete_description:
-        "AntiRoleDelete is a function of AntiNuke that acts on users who delete a lot of roles in a short time\n" +
+    antiroledelete_description: "AntiRoleDelete is a function of AntiNuke that acts on users who delete a lot of roles in a short time\n" +
         ":small_blue_diamond: \`antiroledelete enable/disable\`\n" +
         "Enable/Disable AntiRoleDelete\n" +
         ":small_blue_diamond: \`AntiRoleDelete limit [Number]\`\n" +
@@ -702,8 +658,7 @@ const lang = {
         ":small_blue_diamond: \`AntiRoleDelete action [Sanction]\`\n" +
         "Modify the AntiRoleDelete sanction",
     antiroledelete_small_desc: "Modify AntiRoleDelete settings of the AntiNuke",
-    antiroledelete_examples:
-        "`antiroledelete enable`\n" +
+    antiroledelete_examples: "`antiroledelete enable`\n" +
         "`antiroledelete disable`\n" +
         "`antiroledelete limit 5`\n" +
         "`antiroledelete action ban`",
@@ -712,26 +667,21 @@ const lang = {
     antiroledelete_acted: "[ANTIROLEDELETE] Large number of user-deleted roles detected",
     //antiroledelete action
     antiroledelete_action_use: "antiroledelete action [Ban | Kick | Warn | Mute]",
-    antiroledelete_action_description:
-        "Sets the action to be performed by the BOT if a user exceeds the set limit",
-    antiroledelete_action_examples:
-        "`antiroledelete action ban`",
+    antiroledelete_action_description: "Sets the action to be performed by the BOT if a user exceeds the set limit",
+    antiroledelete_action_examples: "`antiroledelete action ban`",
     antiroledelete_action_updated: (action) => {
         return `AntiRoleDelete action updated, **Action**: \`${action}\``
     },
     //antiroledelete limit
     antiroledelete_limit_use: "antiroledelete limit [Number]",
-    antiroledelete_limit_description:
-        "Sets the limit for the AntiRoleDelete of the AntiNuke",
-    antiroledelete_limit_examples:
-        "`antiroledelete limit 3`",
+    antiroledelete_limit_description: "Sets the limit for the AntiRoleDelete of the AntiNuke",
+    antiroledelete_limit_examples: "`antiroledelete limit 3`",
     antiroledelete_limit_updated: (limit) => {
         return `Modified AntiRoleDelete Limit, **New Limit**: \`${limit}\``
     },
     //antichannelcreate
     antichannelcreate_use: "antichannelcreate [limit | action | enable/disable] {Options}",
-    antichannelcreate_description:
-        "AntiChannelCreate is a function of AntiNuke that acts on users who create many channels in a short time\n" +
+    antichannelcreate_description: "AntiChannelCreate is a function of AntiNuke that acts on users who create many channels in a short time\n" +
         ":small_blue_diamond: \`antichannelcreate enable/disable\`\n" +
         "Enable/Disable AntiChannelCreate\n" +
         ":small_blue_diamond: \`antichannelcreate limit [Number]\`\n" +
@@ -739,8 +689,7 @@ const lang = {
         ":small_blue_diamond: \`antichannelcreate action [Sanction]\`\n" +
         "Modify the AntiChannelCreate sanction",
     antichannelcreate_small_desc: "Modify AntiChannelCreate settings of the AntiNuke",
-    antichannelcreate_examples:
-        "`antichannelcreate enable`\n" +
+    antichannelcreate_examples: "`antichannelcreate enable`\n" +
         "`antichannelcreate disable`\n" +
         "`antichannelcreate limit 5`\n" +
         "`antichannelcreate action ban`",
@@ -749,25 +698,21 @@ const lang = {
     antichannelcreate_acted: "[ANTICHANNELCREATE] Large number of user-created channels detected",
     //antichannelcreate action
     antichannelcreate_action_use: "antichannelcreate action [Ban | Kick | Warn | Mute]",
-    antichannelcreate_action_description:
-        "Sets the action that the BOT should perform if a user exceeds the set limit",
-    antichannelcreate_action_examples:
-        "`antichannelcreate action ban`",
+    antichannelcreate_action_description: "Sets the action that the BOT should perform if a user exceeds the set limit",
+    antichannelcreate_action_examples: "`antichannelcreate action ban`",
     antichannelcreate_action_updated: (action) => {
         return `AntiChannelCreate action updated, **Action**: \`${action}\``
     },
     //antichannelcreate limit
     antichannelcreate_limit_use: "antichannelcreate limit [Number]",
     antichannelcreate_limit_description: "Set limit for AntiChannelCreate of AntiNuke",
-    antichannelcreate_limit_examples:
-        "`antichannelcreate limit 3`",
+    antichannelcreate_limit_examples: "`antichannelcreate limit 3`",
     antichannelcreate_limit_updated: (limit) => {
         return `AntiChannelCreate limit changed, **New Limit**: \`${limit}\``
     },
     //antichanneldelete
     antichanneldelete_use: "antichanneldelete [limit | action | enable/disable] {Options}",
-    antichanneldelete_description:
-        "AntiChannelDelete is a function of AntiNuke that acts on users who delete a lot of channels in a short time\n" +
+    antichanneldelete_description: "AntiChannelDelete is a function of AntiNuke that acts on users who delete a lot of channels in a short time\n" +
         ":small_blue_diamond: \`antichanneldelete enable/disable\`\n" +
         "Enable/Disable AntiChannelDelete\n" +
         ":small_blue_diamond: \`antichanneldelete limit [Number]\`\n" +
@@ -775,8 +720,7 @@ const lang = {
         ":small_blue_diamond: \`antichanneldelete action [Sanzione]\`\n" +
         "Modify the AntiChannelDelete sanction",
     antichanneldelete_small_desc: "Modify the AntiChannelDelete settings of the AntiNuke",
-    antichanneldelete_examples:
-        "`antichanneldelete enable`\n" +
+    antichanneldelete_examples: "`antichanneldelete enable`\n" +
         "`antichanneldelete disable`\n" +
         "`antichanneldelete limit 5`\n" +
         "`antichanneldelete action ban`",
@@ -785,44 +729,37 @@ const lang = {
     antichanneldelete_acted: "[ANTICHANNELDELETE] Large number of user-deleted channels detected",
     //antichanneldelete action
     antichanneldelete_action_use: "antichanneldelete action [Ban | Kick | Warn | Mute]",
-    antichanneldelete_action_description:
-        "Sets the action to be performed by the BOT if a user exceeds the set limit",
-    antichanneldelete_action_examples:
-        "`antichanneldelete action ban`",
+    antichanneldelete_action_description: "Sets the action to be performed by the BOT if a user exceeds the set limit",
+    antichanneldelete_action_examples: "`antichanneldelete action ban`",
     antichanneldelete_action_updated: (action) => {
         return `AntiChannelDelete action updated, **Action**: \`${action}\``
     },
     //antichanneldelete limit
     antichanneldelete_limit_use: "antichanneldelete limit [Number]",
     antichanneldelete_limit_description: "Set the limit for AntiChannelDelete of the AntiNuke",
-    antichanneldelete_limit_examples:
-        "`antichanneldelete limit 3`",
+    antichanneldelete_limit_examples: "`antichanneldelete limit 3`",
     antichanneldelete_limit_updated: (limit) => {
         return `AntiChannelDelete limit changed, **New Limit**: \`${limit}\``
     },
     //antinuke global
     antinukeglobal_use: "antinuke global [Number]",
-    antinukeglobal_description:
-        "**Set the global limit of the AntiNuke**\n" +
+    antinukeglobal_description: "**Set the global limit of the AntiNuke**\n" +
         "The global limit is the sum of all actions committed by the user and recorded by the AntiNuke of the BOT in the last ±30 seconds.\n" +
         "**The BOT will only take into account actions of activated functions, to see which AntiNuke functions are activated use `antinuke info`**",
     antinukeglobal_small_desc: "Sets the global limit of the AntiNuke",
-    antinukeglobal_examples:
-        "`antinuke global 10`",
+    antinukeglobal_examples: "`antinuke global 10`",
     antinukeglobal_updated: (limit) => {
         return `AntiNuke global limit amended, **New Limit**: \`${limit}\``
     },
     antinukeglobal_warnings: "[ANTINUKE] Warning you are exceeding the AntiNuke global limit",
     //antinuke info
     antinuke_info_title: "AntiNuke Settings",
-    antinuke_info_description:
-        "This panel shows all current AntiNuke settings, " +
+    antinuke_info_description: "This panel shows all current AntiNuke settings, " +
         "you can change the various settings using `antinuke [Section]` or via individual commands `antiban {...}`",
     antinuke_info_global_title: "Global Limit",
     //antiraid
     antiraid_use: "antiraid [limit | action | enable/disable | time] {Options}",
-    antiraid_description:
-        "AntiRaid allows you to protect your server from many users entering in a short time" +
+    antiraid_description: "AntiRaid allows you to protect your server from many users entering in a short time" +
         ":small_blue_diamond: \`antiraid enable/disable\`\n" +
         "Enable/Disable AntiRaid\n" +
         ":small_blue_diamond: `limit [Number]`\n" +
@@ -832,8 +769,7 @@ const lang = {
         ":small_blue_diamond: \`antiraid action [Sanction]\`\n" +
         "Modifies the AntiRaid sanction",
     antiraid_small_desc: "Modify AntiRaid settings",
-    antiraid_examples:
-        "`antiraid enable`\n" +
+    antiraid_examples: "`antiraid enable`\n" +
         "`antiraid disable`\n" +
         "`antiraid time 6`\n" +
         "`antiraid limit 5`\n" +
@@ -855,8 +791,7 @@ const lang = {
     antiraid_action_use: "antiraid action [Ban | Kick | Warn | Mute]",
     antiraid_action_description: "Sets the action the bot takes when it detects a raid",
     antiraid_action_small_desc: "Sets the action the bot performs when it detects a raid",
-    antiraid_action_examples:
-        "`antiraid action ban`\n" +
+    antiraid_action_examples: "`antiraid action ban`\n" +
         "`antiraid action none`",
     antiraid_action_updated: (action) => {
         return `antiraid action updated, **Action**: \`${action}\``
@@ -865,16 +800,14 @@ const lang = {
     antiraid_time_use: "antiraid time [Seconds]",
     antiraid_time_description: "Sets the time **in seconds**, in which the raid is to be determined",
     antiraid_time_small_desc: "Sets the time at which raid is to be determined",
-    antiraid_time_examples:
-        "`antiraid time 4`",
+    antiraid_time_examples: "`antiraid time 4`",
     antiraid_time_min: "The minimum time limit for AntiRaid is 3 seconds",
     antiraid_time_updated: (time) => {
         return `Updated AntiRaid time, **New time**: \`${time} Seconds\``
     },
     //autoaction
     autoaction_use: "autoaction [add | remove | list] {Options}",
-    autoaction_description:
-        "Set an action to be performed when a user reaches a certain number of warns\n" +
+    autoaction_description: "Set an action to be performed when a user reaches a certain number of warns\n" +
         ":small_blue_diamond: `autoaction add [number] [ban | kick | mute] {time}`\n" +
         "Add an action that will execute the bot at the set number of warns\n" +
         ":small_blue_diamond: `autoaction remove [number]`\n" +
@@ -882,21 +815,18 @@ const lang = {
         ":small_blue_diamond: `autoaction list`\n" +
         "Show the actions that the bot will perform at certain numbers of warns",
     autoaction_small_desc: "Modify the bot's automatic actions at certain warns",
-    autoaction_examples:
-        "`autoaction list`\n" +
+    autoaction_examples: "`autoaction list`\n" +
         "`autoaction remove 2`\n" +
         "`autoaction add 3 kick`\n" +
         "`autoaction add 5 ban 2d`",
     //autoaction add
     autoaction_add_use: "autoaction add [number] [ban | kick | mute] {time}",
-    autoaction_add_description:
-        "**Actions Available**:\n" +
+    autoaction_add_description: "**Actions Available**:\n" +
         "`ban (Time)` = Ban the user from the server, time optional\n" +
         "kick = Ejects the user from the server\n" +
         "`mute (Time)` = Mute the user, time optional\n" +
         "**Note**: A role must be selected for mute via `setmuterole [Role]`",
-    autoaction_add_examples:
-        "`autoaction add 5 mute 12h`",
+    autoaction_add_examples: "`autoaction add 5 mute 12h`",
     autoaction_already_exists: (number) => {
         return `Another action already exists and is set for \`${number}\` warns. Check the other measures with the command \`autoaction list\`.`
     },
@@ -930,8 +860,7 @@ const lang = {
     //autoaction remove
     autoaction_remove_use: "autoaction remove [Number]",
     autoaction_remove_description: "Remove an autoaction",
-    autoaction_remove_examples:
-        "`autoaction remove 3`",
+    autoaction_remove_examples: "`autoaction remove 3`",
     autoaction_dont_exists: (number) => {
         return `There is no action set for \`${number}\` warns. Check for measures with the command \`autoaction list\``
     },
@@ -943,30 +872,26 @@ const lang = {
     autoaction_reason: '[AUTOACTION] Set warns reached',
     //autodelwarn
     autodelwarn_use: "autodelwarn [enable/disable | Set] {Time}",
-    autodelwarn_description:
-        "This function allows warns to be removed after a specified time\n" +
+    autodelwarn_description: "This function allows warns to be removed after a specified time\n" +
         ":small_blue_diamond: `autodelwarn enable/disable`\n" +
         "Enable/Disable the automatic deletion of warnings\n" +
         ":small_blue_diamond: `autodelwarn set [Time]\n`" +
         "Sets the time after which warnings will be automatically deleted",
     autodelwarn_small_desc: "Sets the automatic deletion of warns",
-    autodelwarn_examples:
-        "`autodelwarn enable`\n" +
+    autodelwarn_examples: "`autodelwarn enable`\n" +
         "`autodelwarn set 1M`",
     autodelwarn_enabled: "`AutoDelWarn enabled!",
     autodelwarn_disabled: "AutoDelWarn disabled!",
     //autodelwarn set
     autodelwarn_set_use: "autodelwarn set [Time]",
     autodelwarn_set_description: "Set the time after which warnings will be automatically deleted",
-    autodelwarn_set_examples:
-        "`autodelwarn set 1m`",
+    autodelwarn_set_examples: "`autodelwarn set 1m`",
     autodelwarn_set_updated: (time) => {
         return `Autodelwarn time updated, **New time**: \`${time}\``
     },
     //blacklist
     blacklist_use: 'blacklist [enable/disable | add/remove | action | list] {Options}',
-    blacklist_description:
-        "The blacklist is a list of banned words that will be automatically deleted, even if they are included in the sentences, **The bot will also try to detect similar sentences/words (with special or little different characters)**\n\n" +
+    blacklist_description: "The blacklist is a list of banned words that will be automatically deleted, even if they are included in the sentences, **The bot will also try to detect similar sentences/words (with special or little different characters)**\n\n" +
         ":small_blue_diamond: `blacklist enable/disable`\n" +
         "Enable/disable the blacklist on the server\n" +
         ":small_blue_diamond: `blacklist add/remove [Word/Phrase]`\n" +
@@ -976,8 +901,7 @@ const lang = {
         ":small_blue_diamond: `blacklist list`\n" +
         "Displays the current list of banned words and phrases",
     blacklist_small_desc: "Open blacklist settings",
-    blacklist_examples:
-        "\`blacklist enable\`\n" +
+    blacklist_examples: "\`blacklist enable\`\n" +
         "\`blacklist add \"word\"\`\n" +
         "\`blacklist add \"one sentence\"\`\n" +
         "\`blacklist remove \"word\"\`\n" +
@@ -987,8 +911,7 @@ const lang = {
     blacklist_disabled: "BlackList disabled!",
     blacklist_add_remove_use: "blacklist add/remove [Word/Phrase]",
     blacklist_add_remove_description: "Add/remove a word or phrase from the BlackList, use `blacklist list` to display banned words/phrases",
-    blacklist_add_remove_examples:
-        "\`blacklist add \"word\"\`\n" +
+    blacklist_add_remove_examples: "\`blacklist add \"word\"\`\n" +
         "\`blacklist add \"one sentence\"\`\n" +
         "\`blacklist remove \"word\"\`\n",
     blacklist_word_already_added: "The inserted word/phrase is already in the blacklist",
@@ -1007,33 +930,28 @@ const lang = {
         return `${member}**, Prohibited word detected!**`
     },
     blacklist_action_use: "blacklist action [Ban | Kick | Warn | Mute | None]",
-    blacklist_action_description:
-        "Sets the action to be performed by the BOT if a user sends a message containing" +
+    blacklist_action_description: "Sets the action to be performed by the BOT if a user sends a message containing" +
         " an impermissible word, use **none** to perform no action (other than delete the message)",
-    blacklist_action_examples:
-        "`blacklist action ban`",
+    blacklist_action_examples: "`blacklist action ban`",
     blacklist_action_updated: (action) => {
         return `blacklist action updated, **Action**: \`${action}\``
     },
     blacklist_action_removed: `BlackList action removed`,
     //bypassrole
     bypassrole_use: "bypassrole [add / remove | list] {@Rule/ID}",
-    bypassrole_description:
-        "Create an \"ignored\" list of roles from the AutoMod\n\n" +
+    bypassrole_description: "Create an \"ignored\" list of roles from the AutoMod\n\n" +
         ":small_blue_diamond: \`bypassrole add/remove [@Role/ID]\`\n" +
         "Add/Remove a role to be \"ignored\N by the AutoMod\n" +
         ":small_blue_diamond: \`bypassrole list\`\n" +
         "Show the list of all roles \"ignored\" by the AutoMod",
     bypassrole_small_desc: "Set roles to be ignored by the AutoMod",
-    bypassrole_examples:
-        "\`bypassrole add @role\`\n" +
+    bypassrole_examples: "\`bypassrole add @role\`\n" +
         "\`bypassrole remove id\`\n" +
         "\`bypassrole list\`",
     //bypassrole add/remove
     bypassrole_add_remove_use: "bypassrole add/remove [@Rule/ID]",
     bypassrole_add_remove_description: "Add/Remove a role to be ignored by the AutoMod",
-    bypassrole_add_remove_examples:
-        "add @ruolo\`bypassrole" +
+    bypassrole_add_remove_examples: "add @ruolo\`bypassrole" +
         "\`bypassrole remove id\`n",
     bypassrole_role_already: "The selected role is already ignored",
     bypassrole_role_not: "The selected role is not in the list of ignored roles",
@@ -1047,22 +965,19 @@ const lang = {
     bypassrole_clear: "No role ignored",
     //bypasschannel
     bypasschannel_use: "bypasschannel [add/remove | list] {#Channel/ID}",
-    bypasschannel_description:
-        "Creates a list of channels ignored by the bot's AutoMod\n" +
+    bypasschannel_description: "Creates a list of channels ignored by the bot's AutoMod\n" +
         ":small_blue_diamond: \`Bypasschannel add/remove [#Channel/ID]\`\n" +
         "Add/Remove a channel from the list of ignored channels\n" +
         ":small_blue_diamond:\`bypasschannel list\`\n" +
         "Show ignored channel list",
     bypasschannel_small_desc: "Set channels to be ignored by the AutoMod",
-    bypasschannel_examples:
-        "`bypasschannel add #channel`\n" +
+    bypasschannel_examples: "`bypasschannel add #channel`\n" +
         "`bypasschannel remove id`\n" +
         "`bypasschannel list`",
     //bypasschannel add/remove
     bypasschannel_add_remove_use: "bypasschannel add/remove [@Rule/ID]",
     bypasschannel_add_remove_description: "Add/remove a channel to be ignored by the AutoMod",
-    bypasschannel_add_remove_examples:
-        "bypasschannel add #channel" +
+    bypasschannel_add_remove_examples: "bypasschannel add #channel" +
         "\`bypasschannel remove id\`n",
     bypasschannel_channel_already: "The selected channel is already ignored",
     bypasschannel_channel_not: "The selected channel is not in the list of ignored channels",
@@ -1076,8 +991,7 @@ const lang = {
     bypasschannel_clear: "No channel ignored",
     //Captcha
     captcha_use: "captcha [Category] {Options}",
-    captcha_description:
-        "Captcha verification allows a code to be sent privately to the user, who must retype it to be verified.\n" +
+    captcha_description: "Captcha verification allows a code to be sent privately to the user, who must retype it to be verified.\n" +
         "Each of the commands below contains a separate help page where you can find more information\n" +
         "**In order to work, verification needs a role to be assigned and it is recommended to set a channel for logs**\n\n" +
         ":small_blue_diamond: `captcha enable/disable`\n" +
@@ -1117,18 +1031,15 @@ const lang = {
     //captcha role
     captcha_role_use: "captcha role [@Role/ID]",
     captcha_role_description: "Add the role to be added to the user at full verification",
-    captcha_role_examples:
-        "\`captcha role 123456789\`\n" +
+    captcha_role_examples: "\`captcha role 123456789\`\n" +
         "\`captcha role @role\`",
     captcha_role_updated: (role) => {
         return `Captcha role updated, **Role**: ${role}`
     },
     //captcha action
     captcha_action_use: "captcha action [Ban | Kick | Warn | Mute | None]",
-    captcha_action_description:
-        "Sets the action to be performed by the BOT if the verification fails",
-    captcha_action_examples:
-        "`captcha action ban`",
+    captcha_action_description: "Sets the action to be performed by the BOT if the verification fails",
+    captcha_action_examples: "`captcha action ban`",
     captcha_action_updated: (action) => {
         return `Captcha verification action updated, **Action**: \`${action}\``
     },
@@ -1231,15 +1142,13 @@ const lang = {
     //CAPTCHA BYPASS
     captcha_bypass_use: "captcha bypass [@User/ID]",
     captcha_bypass_description: "bypass verification for a user",
-    captcha_bypass_examples:
-        "\`captcha bypass @User\`\n" +
+    captcha_bypass_examples: "\`captcha bypass @User\`\n" +
         "\`captcha bypass ID\`",
     captcha_bypassed_cmd: "The user has been successfully verified",
     //CAPTCHA RESEND
     captcha_resend_use: "captcha resend [@User/ID]",
     captcha_resend_description: "Resend verification to a user",
-    captcha_resend_examples:
-        "\`captcha resend @Polliog\`n" +
+    captcha_resend_examples: "\`captcha resend @Polliog\`n" +
         "\`captcha resend 173569203977060353\`",
     captcha_resend_cmd: "Verification started successfully",
     //TICKETS INTERNAL
@@ -1263,8 +1172,7 @@ const lang = {
     ticketsInt_deleted_logs: "Ticket Deleted",
     //TICKETS COMMANDS
     tickets_use: "tickets [Category] {Options}",
-    tickets_description:
-        "Tickets allow for a more orderly handling of user requests by creating a ticket using the ticket command" +
+    tickets_description: "Tickets allow for a more orderly handling of user requests by creating a ticket using the ticket command" +
         "you will create a `panel` (message with a button underneath) from which you interact to create a private ticket.\n" +
         "**Tickets take permissions from the category in which they are created**\n\n" +
         ":small_blue_diamond: `ticket create`\n" +
@@ -1359,13 +1267,12 @@ const lang = {
         "Add/Remove a role from the list\n" +
         ":small_blue_diamond: `autoroles list`\n" +
         "Check your current autoroles",
-    autoroles_examples:
-        "`autoroles user @Role`\n" +
+    autoroles_examples: "`autoroles user @Role`\n" +
         "`autoroles bot id`\n" +
         "`autoroles list`",
     autoroles_small_desc: "Automatically add roles to new users/bots",
-    autoroles_add: (role) => {return `Added ${role} to autoroles`},
-    autoroles_remove: (role) => {return `Removed ${role} from autoroles`},
+    autoroles_add: (role) => { return `Added ${role} to autoroles` },
+    autoroles_remove: (role) => { return `Removed ${role} from autoroles` },
     //autoroles list
     autoroles_list: "AutoRoles List",
     //logs


### PR DESCRIPTION
**Edited the following files**

- `lang.en.js`

**Fixed the following errors:**

- `n!help antinuke` returned wrongly-formatted examples